### PR TITLE
fix issue with pattern shadowing stdlib module `parser`

### DIFF
--- a/pattern/__init__.py
+++ b/pattern/__init__.py
@@ -45,4 +45,9 @@ __license__   = "BSD"
 ####################################################################################################
 
 import os
+try:
+    # prevent en.parser from shadowing the stdlib module parser
+    import compiler, parser
+except ImportError:
+    pass
 __path__.append(os.path.join(__path__[0], "text"))


### PR DESCRIPTION
After installing `pattern`, previously working code started failing with 

```
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/numpy/lib/npyio.py", line 348, in load
    return format.open_memmap(file, mode=mmap_mode)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/numpy/lib/format.py", line 556, in open_memmap
    shape, fortran_order, dtype = read_array_header_1_0(fp)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/numpy/lib/format.py", line 336, in read_array_header_1_0
    d = safe_eval(header)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/numpy/lib/utils.py", line 1137, in safe_eval
    ast = compiler.parse(source, mode="eval")
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/compiler/transformer.py", line 53, in parse
    return Transformer().parseexpr(buf)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/compiler/transformer.py", line 132, in parseexpr
    return self.transform(parser.expr(text))
AttributeError: 'module' object has no attribute 'expr'
```

After digging around a bit, this stems from the standard module `compiler` doing `import parser`. Unfortunately, loading a parser from `pattern` with e.g. `from pattern.en import parse` makes the `compiler` module "see" the wrong parser -- `pattern.text.en.parser` instead of stdlib.

My resolution was to manually `import compiler` before importing the rest of `pattern`, but it feels more like a hack. A better way is not to use stdlib module names, I think.
