### PR TITLE
More Robust MediaWiki Support

### DIFF
--- a/documentation/html/pattern-web.html
+++ b/documentation/html/pattern-web.html
@@ -394,8 +394,8 @@ u&quot;It&#39;s a bunny, rabbit wood. What? A gift.&quot;
 <p>&nbsp;</p>
 <hr />
 <h2><a name="wikipedia"></a>Wikipedia articles</h2>
-<p><span class="inline_code">Wikipedia.search()</span> does not return a list of <span class="inline_code">Result</span> objects. Instead, it returns a single <span class="inline_code">WikipediaArticle</span> for the given (case-sensitive) query. The <span class="inline_code">Wikipedia</span> constructor has an additional <span class="inline_code">language</span> parameter (by default, <span class="inline_code">"en"</span>) that determines the language of the returned articles.</p>
-<pre class="brush:python; gutter:false; light:true;">article = WikipediaArticle(title=&#39;&#39;, source=&#39;&#39;, links=[])</pre><pre class="brush:python; gutter:false; light:true;">article.source              # Article HTML source.
+<p><span class="inline_code">Wikipedia.search()</span> does not return a list of <span class="inline_code">Result</span> objects. Instead, it returns a single <span class="inline_code">MediaWikiArticle</span> for the given (case-sensitive) query. The <span class="inline_code">Wikipedia</span> constructor has an additional <span class="inline_code">language</span> parameter (by default, <span class="inline_code">"en"</span>) that determines the language of the returned articles.</p>
+<pre class="brush:python; gutter:false; light:true;">article = MediaWikiArticle(title=&#39;&#39;, source=&#39;&#39;, links=[])</pre><pre class="brush:python; gutter:false; light:true;">article.source              # Article HTML source.
 article.string              # Article plaintext unicode string.</pre><pre class="brush:python; gutter:false; light:true;">article.title               # Article title.
 article.sections            # Article sections.
 article.links               # List of titles of linked articles.
@@ -406,17 +406,17 @@ article.languages           # Dictionary of (language, article)-items.
 article.language            # Article language (i.e. &#39;en&#39;).
 article.disambiguation      # True if it is a disambiguation page</pre><pre class="brush:python; gutter:false; light:true;">article.plaintext(**kwargs) # See plaintext() for parameter overview.
 article.download(media, **kwargs)
-</pre><p><span class="inline_code">WikipediaArticle.plaintext()</span> is similar to the <span class="inline_code">plaintext()</span> function, but with extra attention for Wikipedia markup. It will remove metadata, infobox, table of contents, annotations, thumbnails and disambiguation links.</p>
+</pre><p><span class="inline_code">MediaWikiArticle.plaintext()</span> is similar to the <span class="inline_code">plaintext()</span> function, but with extra attention for Wikipedia markup. It will remove metadata, infobox, table of contents, annotations, thumbnails and disambiguation links.</p>
 <h3>Wikipedia article sections</h3>
-<p><span class="inline_code">WikipediaArticle.sections</span> is a list of <span class="inline_code">WikipediaSection</span> objects. A section has a title and a number of paragraphs that belong together.</p>
-<pre class="brush:python; gutter:false; light:true;">section = WikipediaSection(article, title=&#39;&#39;, start=0, stop=0, level=1)</pre><pre class="brush:python; gutter:false; light:true;">section.article             # WikipediaArticle parent.
-section.parent              # WikipediaSection this section is part of.
-section.children            # WikipediaSections belonging to this section.</pre><pre class="brush:python; gutter:false; light:true;">section.title               # Section title.
+<p><span class="inline_code">MediaWikiArticle.sections</span> is a list of <span class="inline_code">MediaWikiSection</span> objects. A section has a title and a number of paragraphs that belong together.</p>
+<pre class="brush:python; gutter:false; light:true;">section = MediaWikiSection(article, title=&#39;&#39;, start=0, stop=0, level=1)</pre><pre class="brush:python; gutter:false; light:true;">section.article             # MediaWikiArticle parent.
+section.parent              # MediaWikiSection this section is part of.
+section.children            # MediaWikiSections belonging to this section.</pre><pre class="brush:python; gutter:false; light:true;">section.title               # Section title.
 section.source              # Section HTML source.
 section.string              # Section plaintext unicode string.
 section.content             # Section string minus title.
 section.level               # Section nested depth.
-section.tables              # List of WikipediaTable objects.</pre><p>The following example downloads a Wikipedia article and prints the title of each section, indented according to the section level:</p>
+section.tables              # List of MediaWikiTable objects.</pre><p>The following example downloads a Wikipedia article and prints the title of each section, indented according to the section level:</p>
 <div class="example">
 <pre class="brush:python; gutter:false; light:true;">&gt;&gt;&gt; article = Wikipedia().search(&#39;nodebox&#39;)
 &gt;&gt;&gt; for section in article.sections:
@@ -432,8 +432,8 @@ u&#39;NodeBox for OpenGL&#39;
 u&#39;Applications&#39;
 u&#39;See also&#39;</pre></div>
 <h3>Wikipedia article tables</h3>
-<p><span class="inline_code">WikipediaSection.tables</span> is a list of <span class="inline_code">WikipediaTable</span> objects.&nbsp;A table can have a title, column headers, and rows.&nbsp;</p>
-<pre class="brush:python; gutter:false; light:true;">table = WikipediaTable(section, title=&#39;&#39;, headers=[], rows=[], source=&#39;&#39;)</pre><pre class="brush:python; gutter:false; light:true;">table.section               # WikipediaSection parent.
+<p><span class="inline_code">MediaWikiSection.tables</span> is a list of <span class="inline_code">MediaWikiTable</span> objects.&nbsp;A table can have a title, column headers, and rows.&nbsp;</p>
+<pre class="brush:python; gutter:false; light:true;">table = MediaWikiTable(section, title=&#39;&#39;, headers=[], rows=[], source=&#39;&#39;)</pre><pre class="brush:python; gutter:false; light:true;">table.section               # MediaWikiSection parent.
 table.source                # Table HTML source.
 table.title                 # Table title.
 table.headers               # List of table column headers.

--- a/examples/01-web/04-wikipedia.py
+++ b/examples/01-web/04-wikipedia.py
@@ -10,7 +10,7 @@ from pattern.web import Wikipedia
 engine = Wikipedia(language="en")
 
 # Contrary to other search engines in the module,
-# Wikipedia simply returns one WikipediaArticle object (or None) instead of a list of results.
+# Wikipedia simply returns one MediaWikiArticle object (or None) instead of a list of results.
 article = engine.search("alice in wonderland", cached=True, timeout=30)
 
 print article.title               # Article title (may differ from the search query).
@@ -24,7 +24,7 @@ print
 #print article.string # The full article content, plain text with HTML tags stripped.
 
 # An article is made up of different sections with a title.
-# WikipediaArticle.sections is a list of WikipediaSection objects.
+# MediaWikiArticle.sections is a list of MediaWikiSection objects.
 # Each section has a title + content and can have a linked parent section or child sections.
 for s in article.sections:
     print s.title.upper()

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -449,7 +449,8 @@ class TestSearchEngine(unittest.TestCase):
              "Yahoo": (web.YAHOO,       web.YAHOO_LICENSE,       web.Yahoo),
               "Bing": (web.BING,        web.BING_LICENSE,        web.Bing),
            "Twitter": (web.TWITTER,     web.TWITTER_LICENSE,     web.Twitter),
-         "Wikipedia": (web.WIKIPEDIA,   web.WIKIPEDIA_LICENSE,   web.Wikipedia),
+         "Wikipedia": (web.MEDIAWIKI,   web.MEDIAWIKI_LICENSE,   web.Wikipedia),
+             "Wikia": (web.MEDIAWIKI,   web.MEDIAWIKI_LICENSE,   web.Wikia),
             "Flickr": (web.FLICKR,      web.FLICKR_LICENSE,      web.Flickr),
           "Facebook": (web.FACEBOOK,    web.FACEBOOK_LICENSE,    web.Facebook),
           "Products": (web.PRODUCTWIKI, web.PRODUCTWIKI_LICENSE, web.Products)
@@ -459,7 +460,7 @@ class TestSearchEngine(unittest.TestCase):
         # Assert SearchEngine standard interface for any api:
         # Google, Yahoo, Bing, Twitter, Wikipedia, Flickr, Facebook, Products, Newsfeed.
         # SearchEngine.search() returns a list of Result objects with unicode fields, 
-        # except Wikipedia which returns a WikipediaArticle.
+        # except Wikipedia which returns a MediaWikiArticle.
         if api == "Yahoo" and license == ("",""): 
             return
         t = time.time()
@@ -471,7 +472,7 @@ class TestSearchEngine(unittest.TestCase):
         self.assertEqual(e.throttle, 0.25)
         self.assertEqual(e.language, "en")
         self.assertEqual(v.query, query)
-        if source != web.WIKIPEDIA:
+        if source != web.MEDIAWIKI:
             self.assertEqual(v.source, source)
             self.assertEqual(v.type, type)
             self.assertEqual(len(v), 1)
@@ -483,15 +484,15 @@ class TestSearchEngine(unittest.TestCase):
             self.assertTrue(isinstance(v[0].author, unicode))
             self.assertTrue(isinstance(v[0].date, unicode))
         else:
-            self.assertTrue(isinstance(v, web.WikipediaArticle))
+            self.assertTrue(isinstance(v, web.MediaWikiArticle))
         # Assert zero results for start < 1 and count < 1.
         v1 = e.search(query, start=0)
         v2 = e.search(query, count=0)
-        if source != web.WIKIPEDIA:
+        if source != web.MEDIAWIKI:
             self.assertEqual(len(v1), 0)
             self.assertEqual(len(v2), 0)
         else:
-            self.assertTrue(isinstance(v1, web.WikipediaArticle))
+            self.assertTrue(isinstance(v1, web.MediaWikiArticle))
             self.assertEqual(v2, None)
         # Assert SearchEngineTypeError for unknown type.
         self.assertRaises(web.SearchEngineTypeError, e.search, query, type="crystall-ball")
@@ -507,6 +508,8 @@ class TestSearchEngine(unittest.TestCase):
         self._test_search_engine("Twitter",   *self.api["Twitter"])
     def test_search_wikipedia(self):
         self._test_search_engine("Wikipedia", *self.api["Wikipedia"])
+    def test_search_wikia(self):
+        self._test_search_engine("Wikia",     *self.api["Wikia"], **{"query": "games"})
     def test_search_flickr(self):
         self._test_search_engine("Flickr",    *self.api["Flickr"], **{"type": web.IMAGE})
     def test_search_facebook(self):
@@ -617,7 +620,7 @@ class TestSearchEngine(unittest.TestCase):
     def test_wikipedia_article(self):
         source, license, Engine = self.api["Wikipedia"]
         v = Engine(license).search("cat", cached=False)
-        # Assert WikipediaArticle properties.
+        # Assert MediaWikiArticle properties.
         self.assertTrue(isinstance(v.title,      unicode))
         self.assertTrue(isinstance(v.string,     unicode))
         self.assertTrue(isinstance(v.links,      list))
@@ -625,7 +628,7 @@ class TestSearchEngine(unittest.TestCase):
         self.assertTrue(isinstance(v.external,   list))
         self.assertTrue(isinstance(v.media,      list))
         self.assertTrue(isinstance(v.languages,  dict))
-        # Assert WikipediaArticle properties content.
+        # Assert MediaWikiArticle properties content.
         self.assertTrue(v.string  == v.plaintext())
         self.assertTrue(v.html    == v.source)
         self.assertTrue("</div>"  in v.source)
@@ -637,10 +640,10 @@ class TestSearchEngine(unittest.TestCase):
         self.assertTrue("chat"    in v.languages["fr"].lower())
         self.assertTrue(v.external[0].startswith("http"))
         self.assertTrue(v.media[0].endswith(("jpg","png","gif","svg")))
-        print "pattern.web.WikipediaArticle"
+        print "pattern.web.MediaWikiArticle"
         
     def test_wikipedia_article_sections(self):
-        # Assert WikipediaArticle.sections structure.
+        # Assert MediaWikiArticle.sections structure.
         # The test may need to be modified if the Wikipedia "Cat" article changes.
         source, license, Engine = self.api["Wikipedia"]
         v = Engine(license).search("cat", cached=False)
@@ -669,7 +672,7 @@ class TestSearchEngine(unittest.TestCase):
         # Test section tables.
         # XXX should test <td colspan="x"> more thoroughly.
         self.assertTrue(len(v.sections[1].tables) > 0)
-        print "pattern.web.WikipediaSection"
+        print "pattern.web.MediaWikiSection"
 
     def test_products(self):
         # Assert product reviews and score.


### PR DESCRIPTION
Your library currently only supports Wikipedia as a source, but for all intents and purposes supports any site built off of the MediaWiki platform. I've updated the web module to include an abstract class, MediaWiki, which Wikipedia now inherits from. I have also implemented a class called Wikia, which will expose data for over 200,000 wikis. The difference between the Wikia class and the Wikipedia class is that Wikia's subdomains do not directly correlate with the wiki's language. Otherwise, they should be functionally the same. Please let me know if you have any questions on this. Thanks!
