### PR TITLE
documenting graph.Node.id as string

### DIFF
--- a/documentation/html/pattern-graph.html
+++ b/documentation/html/pattern-graph.html
@@ -53,7 +53,7 @@
 <pre class="brush:python; gutter:false; light:true;">node = Node(id=&quot;&quot;, radius=5, **kwargs)</pre><pre class="brush:python; gutter:false; light:true;">node.graph                     # Parent Graph.
 node.edges                     # List of Edge objects.
 node.links                     # List of Node objects.
-node.id                        # Unique string or int.</pre><pre class="brush:python; gutter:false; light:true;">node.x                         # Horizontal offset.
+node.id                        # Unique string.</pre><pre class="brush:python; gutter:false; light:true;">node.x                         # Horizontal offset.
 node.y                         # Vertical offset.
 node.force                     # Vector, updated by Graph.layout.
 node.radius                    # Default: 5


### PR DESCRIPTION
graph.Node.id is escaped in _data.
