### PR TITLE
Generator for MediaWiki/Wikia

### DIFF
--- a/examples/01-web/13-wikia.py
+++ b/examples/01-web/13-wikia.py
@@ -20,5 +20,6 @@ counter = 0
 try:
     for page in ArticleSet:
         print counter, page.title
+        counter = counter + 1
 except URLTimeout:
     print "Timeout error."


### PR DESCRIPTION
This changeset introduces MediaWikiArticleSet and WikiaArticleSet classes. They are generators that provide instances of MediaWikiArticle.  

MediaWikiArticleSet iterates using MediaWiki.list(), which uses the traditional MediaWiki API to list all pages, and then the MediaWiki.search() command to access those pages based on their title.

WikiaArticleSet uses MediaWiki.list() to get the article IDs, and then uses those IDs on Wikia's search backend to access the source for multiple pages at once. 

This is still all considerably slow, and likely very hard to scale for really data-intensive stuff, but it's at least a step in the right direction.
