### PR TITLE
ERROR: test_url_redirect (__main__.TestURL)

### DIFF
--- a/test/test_web.py
+++ b/test/test_web.py
@@ -210,7 +210,7 @@ class TestURL(unittest.TestCase):
         # Assert URL redirected URL (this depends on where you are).
         # In Belgium, it yields "http://www.google.be/".
         v = web.URL(self.live).redirect
-        print "pattern.web.URL.redirect: " + self.live + " => " + v
+        print "pattern.web.URL.redirect: " + self.live + " => " + (v or "None")
 
     def test_abs(self):
         # Assert absolute URL (special attention for anchors).


### PR DESCRIPTION
When redirect is None test_web is failing with following error:
# 
## ERROR: test_url_redirect (**main**.TestURL)

Traceback (most recent call last):
  File "C:\git\pattern\test\test_web.py", line 214, in test_url_redirect
    print "pattern.web.URL.redirect: " + self.live + " => " + v
TypeError: cannot concatenate 'str' and 'NoneType' objects
# 

Modified print statement to handle NoneType.
