### PR TITLE
Fix function call: don't use non-existent argument.

### DIFF
--- a/pattern/metrics.py
+++ b/pattern/metrics.py
@@ -178,7 +178,7 @@ def sensitivity(classify=lambda document:False, documents=[]):
 def specificity(classify=lambda document:False, documents=[]):
     """ Returns the percentage of negative cases correctly classified as negative.
     """
-    TP, TN, FP, FN = confusion_matrix(classify, documents, average=None)
+    TP, TN, FP, FN = confusion_matrix(classify, documents)
     return float(TN) / ((TN + FP) or 1)
 
 TPR = sensitivity # true positive rate


### PR DESCRIPTION
Hi,

I'm trying to improve pyflakes (it's static code analyzer for Python https://github.com/pyflakes/pyflakes) so it will be able to detect function calls errors (like UnexpectedArgument).

As a part of testing I ran my version of pyflakes on your project (because it's quite popular Python project ^_^).
It found this bug.

Please review the change.
Thanks.
