### PR TITLE
optimize naive bayes classifier caching the log-likelihood denominator

### DIFF
--- a/pattern/vector/__init__.py
+++ b/pattern/vector/__init__.py
@@ -2093,7 +2093,7 @@ class NaiveBayes(Classifier):
         p = defaultdict(float)
         for type in self._classes:
             if self._method == MULTINOMIAL:
-                if not type in self._cache_lh_value:
+                if not type in self._cache_lh_sum:
                     self._cache_lh_sum[type] = float(sum(self._likelihood[type].itervalues()))
                 d = self._cache_lh_sum[type]
             if self._method in (BINOMIAL, BERNOUILLI):


### PR DESCRIPTION
Hi, this is just a very simple optimization to make testing of naive bayes classifier much faster.
