### PR TITLE
Fix spelling suggestion so that it preserves capitalization

### DIFF
--- a/pattern/text/__init__.py
+++ b/pattern/text/__init__.py
@@ -1907,7 +1907,10 @@ class Spelling(lazydict):
         candidates = [(self.get(c, 0.0), c) for c in candidates]
         s = float(sum(p for p, w in candidates) or 1)
         candidates = sorted(((p / s, w) for p, w in candidates), reverse=True)
-        candidates = [(w.istitle() and w.title() or w, p) for p, w in candidates] # case-sensitive
+        if w.istitle():  # Preserve capitalization
+            candidates = [(word.title(), p) for p, word in candidates]
+        else:
+            candidates = [(word, p) for p, word in candidates]
         return candidates
 
 #### MULTILINGUAL ##################################################################################

--- a/test/test_en.py
+++ b/test/test_en.py
@@ -275,17 +275,22 @@ class TestSpelling(unittest.TestCase):
         print "pattern.en.suggest()"
 
     def test_spelling_oneletter_words(self):
-      self.assertEqual(en.suggest("I"), [("I", 1.0)])
-      self.assertEqual(en.suggest("a"), [("a", 1.0)])
+        self.assertEqual(en.suggest("I"), [("I", 1.0)])
+        self.assertEqual(en.suggest("a"), [("a", 1.0)])
 
     def test_spelling_numbers(self):
-      self.assertEqual(en.suggest("42"), [("42", 1.0)])
-      self.assertEqual(en.suggest("3.1415"), [("3.1415", 1.0)])
+        self.assertEqual(en.suggest("42"), [("42", 1.0)])
+        self.assertEqual(en.suggest("3.1415"), [("3.1415", 1.0)])
 
     def test_spelling_punctuation(self):
-      self.assertEqual(en.suggest("!"), [("!", 1.0)])
-      self.assertEqual(en.suggest("?"), [("?", 1.0)])
-      self.assertEqual(en.suggest("."), [('.', 1.0)])
+        self.assertEqual(en.suggest("!"), [("!", 1.0)])
+        self.assertEqual(en.suggest("?"), [("?", 1.0)])
+        self.assertEqual(en.suggest("."), [('.', 1.0)])
+
+    def test_suggest_preserves_capitalization(self):
+        suggestion = en.suggest("The")
+        self.assertEqual(suggestion[0][0], "The")
+
 
 
 #---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The [last commit](https://github.com/clips/pattern/commit/d1d719540f195f3028e24f4d2e536d73e9fef210) introduced a bug that caused spelling suggestions to ignore capitalization, e.g. `"The" -> ("the", 1.0)`. 

This patch reverts the last few lines of the `suggest()` method back to the old logic. A basic test was also added for this.
