### PR TITLE
Add comma (punctuation) for detecting section title in content

### DIFF
--- a/pattern/web/__init__.py
+++ b/pattern/web/__init__.py
@@ -1877,9 +1877,9 @@ class MediaWikiSection(object):
     def content(self):
         # ArticleSection.string, minus the title.
         s = self.plaintext()
-        t = plaintext(self.title)
-        if s == t or (len(s) > len(t) and s.startswith(t) and s[len(t)] != " "):
-            return s[len(t):].lstrip()
+        # Check that the title isn't part of the first sentence.
+        if s == self.title or re.search("^%s[^ ,]" % re.escape(self.title), s):
+            return s[len(self.title):].lstrip()
         return s
 
     @property


### PR DESCRIPTION
When getting section content, a section title followed by a space or comma is likely to be part of the section's content. The conversion of self.title to plaintext was deleted as it now happens beforehand in the parse of the article's sections.
