### PR TITLE
Add pattern.web.locale module to packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "pattern.web.feed",
         "pattern.web.imap",
         "pattern.web.json",
+        "pattern.web.locale",
         "pattern.web.oauth",
         "pattern.web.pdf",
         "pattern.web.soup",


### PR DESCRIPTION
The pattern.web.locale module does not get installed properly when running "python setup.py install".
