### PR TITLE
Check length to prevent IndexErrors

### DIFF
--- a/pattern/text/de/inflect.py
+++ b/pattern/text/de/inflect.py
@@ -376,7 +376,7 @@ class Verbs(_Verbs):
         b = b.replace("eeiss", "eiss")
         b = b.replace("eeid", "eit")
         # Subjunctive: wechselte => wechseln
-        if not b.endswith(("e", "l")) and not (b.endswith("er") and not b[-3] in VOWELS):
+        if not b.endswith(("e", "l")) and not (b.endswith("er") and len(b) >= 3 and not b[-3] in VOWELS):
             b = b + "e"
         # abknallst != abknalln => abknallen
         if b.endswith(("hl", "ll", "ul", "eil")):


### PR DESCRIPTION
I always got an IndexError for certain input. Just using b[-3] is not safe. Even if b.endswith('er') is true, b could still be less than three chars long (<=> b = 'er'). Example: "erst" raises an IndexError. It's not a noun of course, but still should not raise an IndexError.
