### PR TITLE
Constructing a Color with an Array also works when a=0.

### DIFF
--- a/pattern/canvas.js
+++ b/pattern/canvas.js
@@ -559,7 +559,7 @@ var Color = Class.extend({
             g=r.g; b=r.b; a=r.a; r=r.r;
         // One value, array with R,G,B,A values.
         } else if (r instanceof Array) {
-            g=r[1]; b=r[2]; a=r[3]||1; r=r[0];
+            g=r[1]; b=r[2]; a=r[3] !== undefined ? r[3] : 1; r=r[0];
         // No value or null, transparent black.
         } else if (r === undefined || r == null) {
             r=0; g=0; b=0; a=0;

--- a/test/test_canvas.js
+++ b/test/test_canvas.js
@@ -170,6 +170,7 @@ var test_canvas = {
             assert(Array.eq(new Color(0,0,0.5).rgba(), [0,0,0.5,1]));
             assert(Array.eq(new Color(1,1,1,1).rgba(), [1,1,1,1]));
             assert(Array.eq(new Color([1,0,0,1]).rgba(), [1,0,0,1]));
+            assert(Array.eq(new Color([1,0,0,0]).rgba(), [1,0,0,0]));
             assert(Array.eq(new Color(255,255,0,0, {base:255}).rgba(), [1,1,0,0]));
             assert(Array.eq(new Color(1,1,0.5,0, {colorspace:HSB}).rgba(), [0.5,0,0,0]));
             assert(Array.eq(new Color(new Color(0)).rgba(), [0,0,0,1]));


### PR DESCRIPTION
The `r[3] || 1` expression returns the wrong result when r[3] is zero
(since this makes the expression fall through). We now check for
undefined.
