### PR TITLE
Fix a bug in _rgb2hex.

### DIFF
--- a/pattern/canvas.js
+++ b/pattern/canvas.js
@@ -757,8 +757,17 @@ var lineCap = linecap;
 function _rgb2hex(r, g, b) {
     /* Converts the given R,G,B values to a hexadecimal color string.
      */
-    parseHex = function(i) { 
-        return ((i == 0)? "00" : (i.length < 2)? "0"+i : i).toString(16).toUpperCase(); 
+    parseHex = function(i) {
+        var s;
+        if (i == 0) {
+            return "00";
+        } else {
+            s = i.toString(16).toUpperCase();
+            if (s.length < 2) {
+                s = "0" + s;
+            }
+            return s;
+        }
     }
     return "#"
         + parseHex(Math.round(r * 255)) 

--- a/test/test_canvas.js
+++ b/test/test_canvas.js
@@ -196,6 +196,12 @@ var test_canvas = {
             assert(Math.round(rgba[3], 1) == 1.0);
             console.log("Color.rotate()")
         }
+        this.test_rgb2hex = function() {
+            assert(_rgb2hex(0, 0, 0) === '#000000');
+            assert(_rgb2hex(0.01, 0.5, 0.99) === '#0380FC');
+            assert(_rgb2hex(1, 1, 1) === '#FFFFFF');
+            console.log("_rgb2hex()")
+        }
     },
 
     //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Small values would be converted to single-digit hexadecimal values
because of an incorrect length calculation.
