### PR TITLE
General heuristic for differentiating title and start of section content

### DIFF
--- a/pattern/web/__init__.py
+++ b/pattern/web/__init__.py
@@ -25,7 +25,7 @@ import StringIO
 import bisect
 import itertools
 import new
-
+import string
 import api
 import feed
 import oauth
@@ -1983,7 +1983,7 @@ class MediaWikiSection(object):
         # ArticleSection.string, minus the title.
         s = self.plaintext()
         t = plaintext(self.title)
-        if s == t or (len(s) > len(t)) and s.startswith(t) and s[len(t)] not in (",", " "):
+        if s == t or (len(s) > len(t)) and s.startswith(t) and s[len(t)] not in string.punctuation+" ":
             return s[len(t):].lstrip()
         return s
 


### PR DESCRIPTION
For example see the first section of http://en.wikipedia.org/wiki/KGNU with title "KGNU" and first word "KGNU-AM-FM". Without detecting the "-" the section's content would start with "-AM-FM".
