### PR TITLE
add tox.ini file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist=py{26,27}
+#envlist=py{26,27,32,33,34},pypy
+
+[testenv]
+commands=
+    nosetests
+deps=
+    nose
+
+[testenv:py26]
+deps=
+    unittest2
+    {[testenv]deps}


### PR DESCRIPTION
This adds a simple tox.ini file to run the tests across multiple python version locally with [tox](tox.readthedocs.org/en/latest/).

_At the moment this does not work for me (dependancies? or local setup?), as commented in #62._
