### PR TITLE
Fixed singularize to handle -ss singular nouns

### DIFF
--- a/pattern/text/en/inflect.py
+++ b/pattern/text/en/inflect.py
@@ -506,7 +506,7 @@ singular_rules = [
     # -a
     (r'(?i)([ti])a$'          , '\\1um'   ),
     (r'(?i)(n)ews$'           , '\\1ews'  ),
-    (r'(?i)s$'                , ''        ),
+    (r'(?i)([^s])s$'          , '\\1'     ),
 ]
 
 # For performance, compile the regular expressions only once:


### PR DESCRIPTION
Code didn't condition final removal of -s on not following another s. 
See rules from http://www.csse.monash.edu.au/~damian/papers/HTML/Plurals.html:

`if suffix(-[^s]s), return inflection(-s,-) `

Previously, singularize('business') => 'busines' which is incorrect.