### PR TITLE
Fixing singular forms of words ending in 'our' and in 'lives'

### DIFF
--- a/pattern/text/en/inflect.py
+++ b/pattern/text/en/inflect.py
@@ -488,6 +488,7 @@ singular_rules = [
     (r"([^d]ea)ves$"          , "\\1f"    ),
     (r"arves$"                , "arf"     ),
     (r"erves$"                , "erve"    ),
+    (r"([\w])lives"           , "\\1live" ),
     (r"([nlw]i)ves$"          , "\\1fe"   ),
     (r'(?i)([lr])ves$'        , '\\1f'    ),
     (r"([aeo])ves$"           , "\\1ve"   ),
@@ -572,8 +573,7 @@ singular_irregular = {
        "occipita": "occiput", 
       "octopodes": "octopus", 
           "opera": "opus", 
-         "opuses": "opus", 
-            "our": "my",
+         "opuses": "opus",
            "oxen": "ox", 
           "penes": "penis", 
         "penises": "penis", 
@@ -585,6 +585,10 @@ singular_irregular = {
         "trilbys": "trilby", 
          "turves": "turf", 
             "zoa": "zoon",
+}
+
+singular_pronouns = {
+    "our": "my",
 }
 
 def singularize(word, pos=NOUN, custom={}):
@@ -613,6 +617,9 @@ def singularize(word, pos=NOUN, custom={}):
     for x in singular_irregular:
         if w.endswith(x):
             return re.sub('(?i)'+x+'$', singular_irregular[x], word)
+    for x in singular_pronouns:
+        if w == x:
+            return singular_pronouns[x]
     for suffix, inflection in singular_rules:
         m = suffix.search(word)
         g = m and m.groups() or [] 


### PR DESCRIPTION
The rule `'our': 'my'` in singular_irregular was causing many words that end in 'our' (flour, your, sour, colour, etc...) to be incorrectly singularized. This change moves 'our' -> 'my' into a new special list of singular_pronouns so that separate logic can handle these cases. 

The rule `(r"([nlw]i)ves$"          , "\\1fe"   ),` in singular_rules was causing words that end in 'lives' (olives, etc..) to be incorrectly singularized. The rule is still necessary for the word 'lives' itself but a new rule with higher precedence was added to handle the case of words ending in 'lives'. 