### PR TITLE
Fix #140:Pattern 2.6 not Python 3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ if sys.argv[-1] == "zip":
                 x.write(d.join(s))
                 x.close()
     z.close()
-    print n
-    print hashlib.sha256(open(z.filename).read()).hexdigest()
+    print (n)
+    print (hashlib.sha256(open(z.filename).read()).hexdigest())
     sys.exit(0)
 
 #---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
There was a syntax error in print.Due to recent changes in python3.
Reference: https://docs.python.org/3/whatsnew/3.0.html#print-is-a-function