### PR TITLE
Made changes for BUG #141

### DIFF
--- a/pattern/text/en/inflect.py
+++ b/pattern/text/en/inflect.py
@@ -602,17 +602,25 @@ def singularize(word, pos=NOUN, custom={}):
         return singularize(word[:-1]) + "'s"
     w = word.lower()
     for x in singular_uninflected:
-        if x.endswith(w):
-            return word
+		if x==w:
+			return word
+        # Changed from endswith to ==
+        #if x.endswith(w):
     for x in singular_uncountable:
-        if x.endswith(w):
+        if x==w:
             return word
+        # Changed from endswith to ==
+        #if x.endswith(w):
     for x in singular_ie:
         if w.endswith(x+"s"):
-            return w
+            return x
+        # Changed. We need to return the singular word
+        #return w
     for x in singular_irregular:
-        if w.endswith(x):
-            return re.sub('(?i)'+x+'$', singular_irregular[x], word)
+        if x==w:
+            return word
+        #if w.endswith(x):
+        #    return re.sub('(?i)'+x+'$', singular_irregular[x], word)
     for suffix, inflection in singular_rules:
         m = suffix.search(word)
         g = m and m.groups() or [] 


### PR DESCRIPTION
Signed-off-by: anantguptadbl <anantguptadbl@gmail.com>

The way the singularize function is structured, it was creating issues for few words that appear at the end of large words
Within the function there were specific calls for endswith
For the words listed in 
singular_irregular
singular_uncountable
singular_uninflected

```
for x in singular_uninflected:
	if x.endswith(w):
			return word


```
the above is changed to
```

for x in singular_uninflected:
	if x==w:
		return word
```


The function endswith will not add value, so I replaced it with a simple equals comparison