### PR TITLE
Python2 check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,11 @@
 
 import sys
 
+if sys.version_info[:2] < (2, 5):
+    raise RuntimeError("Python 2.5+ required to use pattern")
+
 if sys.version_info[0] != 2:
-    raise Exception("Wrong version of Python, pattern only supports Python 2")
+    raise RuntimeError("pattern only supports Python 2")
 
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #### PATTERN #######################################################################################
 
 import sys
+
+if sys.version_info[0] != 2:
+    raise Exception("Wrong version of Python, pattern only supports Python 2")
+
 import os
 
 from setuptools import setup
@@ -37,8 +41,8 @@ if sys.argv[-1] == "zip":
                 x.write(d.join(s))
                 x.close()
     z.close()
-    print n
-    print hashlib.sha256(open(z.filename).read()).hexdigest()
+    print (n)
+    print (hashlib.sha256(open(z.filename).read()).hexdigest())
     sys.exit(0)
 
 #---------------------------------------------------------------------------------------------------
@@ -125,7 +129,7 @@ setup(
         "Natural Language :: Spanish",
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
-        "Programming Language :: Python",
+        "Programming Language :: Python :: 2 :: Only",
         "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
         "Topic :: Multimedia :: Graphics",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
I encountered the error message in #140. This change will make things a little more obvious for those who are not as familiar with Python and versioning issues.

setup.py exits early with an exception (RuntimeError) if:
Python version is less than 2.5, or
Major version is not 2

Added parentheses on print statements so that a ParseError is not generated before the script is run.
Tested install and basic use on Python 2.5 and 2.7 (and 3.5 to check that it rejects).