### PR TITLE
Add package installation subprocess in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,15 @@ from io import open
 
 from setuptools import setup
 
+from subprocess import call
+
+cmd      = "pip3 install"
+packages = [
+    "feedparser", "backports.csv", "cherrypy", 
+    "mysqlclient", "pdfminer.six", "python-docx"]
+
+call(cmd.split() + packages)
+
 from pattern import __version__
 
 #---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Even if the setup process completed without any problem, I had to install all the missing packages one by one — for this reason, I propose a simple way to automate this phase with the `subprocess module`.

The advantage of `call()` vs `os.system()` is that it is more flexible, enabling you to get the stdout, stderr, status code, better error handling and so on.