### PR TITLE
Make mysqlclient an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ setup(
     install_requires = [
         "future",
         "backports.csv",
-        "mysqlclient",
         "beautifulsoup4",
         "lxml",
         "feedparser",
@@ -149,5 +148,8 @@ setup(
         "cherrypy",
         "requests"
     ],
+    extra_requires = {
+        'mysql': ["mysqlclient"],
+    },
     zip_safe = False
 )


### PR DESCRIPTION
MySQL shouldn't be a core dependency, I've moved it to an extra package which can be installed as `pip install pattern[mysql]` if users wish to install with mysql support.