### PR TITLE
Pin Python and some dependencies versions to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 dist: precise
 
 python:
-  - "3.6"
+  - "3.6.5"
 
 before_install:
   - export TZ=Europe/Brussels
@@ -11,6 +11,8 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda update --yes conda
+  - conda create --yes --name pattern python=$TRAVIS_PYTHON_VERSION
+  - source activate pattern
   - conda install --yes numpy scipy
   - pip install --quiet pytest pytest-cov pytest-xdist chardet
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,11 @@ install:
   # Install and compile libsvm and liblinear
   - sudo apt-get install -y build-essential
   - git clone https://github.com/cjlin1/libsvm
-  - cd libsvm; make lib; sudo cp libsvm.so.2 /lib; sudo ln -s /lib/libsvm.so.2 /lib/libsvm.so; cd ..
+  - cd libsvm; git checkout v322
+  - make lib; sudo cp libsvm.so.2 /lib; sudo ln -s /lib/libsvm.so.2 /lib/libsvm.so; cd ..
   - git clone https://github.com/cjlin1/liblinear
-  - cd liblinear; make lib; sudo cp liblinear.so.3 /lib; sudo ln -s /lib/liblinear.so.3 /lib/liblinear.so; cd ..
+  - cd liblinear; git checkout v220
+  - make lib; sudo cp liblinear.so.3 /lib; sudo ln -s /lib/liblinear.so.3 /lib/liblinear.so; cd ..
 
 script:
   - pytest --cov=pattern

--- a/test/test_text.py
+++ b/test/test_text.py
@@ -9,6 +9,7 @@ from builtins import map, zip, filter
 from builtins import object, range
 
 import os
+from random import seed
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import unittest
@@ -92,6 +93,7 @@ class TestModel(unittest.TestCase):
     def test_model(self):
         # Assert SLP language model.
         v = text.Model()
+        seed(0) # Reset RNG seed set by current time inside the constructor above
         for i in range(2):
             v.train("black", "JJ", previous=("the", "DT"), next=("cat", "NN"))
             v.train("on", "IN", previous=("sat", "VBD"), next=("the", "DT"))

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -88,6 +88,18 @@ class TestUtilityFunctions(unittest.TestCase):
             self.assertEqual(vector.shi(a), b)
         print("pattern.vector.shi()")
 
+    def test_mix(self):
+        # Assert mix() generate as expected, merging lists with the given interval
+        self.assertEqual(
+            list(vector.mix([[1, 2, 3, 4], ["a", "b"]], n=2)),
+            [1, 2, "a", 3, 4, "b"])
+
+    def test_bin(self):
+        # Assert bin() returns expected dict, with keys as defined by the param `key`
+        self.assertEqual(
+            vector.bin([["a", 1], ["a", 2], ["b", 3]], key=lambda x: x[0]),
+            {"a": [["a", 1], ["a", 2]], "b": [["b", 3]]})
+
     def test_shuffled(self):
         # Assert shuffled() <=> sorted().
         v1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -944,9 +944,9 @@ class TestClassifier(unittest.TestCase):
         # Assert the accuracy of the classifier.
         A, P, R, F, o = vector.NB.test(self.model, folds=10, method=vector.BERNOUILLI)
         #print(A, P, R, F, o)
-        self.assertTrue(P >= 0.88)
-        self.assertTrue(R >= 0.89)
-        self.assertTrue(F >= 0.88)
+        self.assertGreaterEqual(P, 0.88)
+        self.assertGreaterEqual(R, 0.89)
+        self.assertGreaterEqual(F, 0.88)
 
     def test_igtree(self):
         # Assert information gain tree classification.
@@ -954,9 +954,9 @@ class TestClassifier(unittest.TestCase):
         # Assert the accuracy of the classifier.
         A, P, R, F, o = vector.IGTREE.test(self.model, folds=10, method=vector.GAINRATIO)
         #print(A, P, R, F, o)
-        self.assertTrue(P >= 0.87)
-        self.assertTrue(R >= 0.88)
-        self.assertTrue(F >= 0.89)
+        self.assertGreaterEqual(P, 0.87)
+        self.assertGreaterEqual(R, 0.88)
+        self.assertGreaterEqual(F, 0.89)
 
     def test_knn(self):
         # Assert nearest-neighbor classification.
@@ -964,9 +964,9 @@ class TestClassifier(unittest.TestCase):
         # Assert the accuracy of the classifier.
         A, P, R, F, o = vector.KNN.test(self.model, folds=10, k=2, distance=vector.COSINE)
         #print(A, P, R, F, o)
-        self.assertTrue(P >= 0.91)
-        self.assertTrue(R >= 0.92)
-        self.assertTrue(F >= 0.92)
+        self.assertGreaterEqual(P, 0.91)
+        self.assertGreaterEqual(R, 0.92)
+        self.assertGreaterEqual(F, 0.92)
 
     def test_slp(self):
         random.seed(1)
@@ -975,9 +975,9 @@ class TestClassifier(unittest.TestCase):
         # Assert the accuracy of the classifier.
         A, P, R, F, o = vector.SLP.test(self.model, folds=10, iterations=3)
         #print(A, P, R, F, o)
-        self.assertTrue(P >= 0.90)
-        self.assertTrue(R >= 0.91)
-        self.assertTrue(F >= 0.91)
+        self.assertGreaterEqual(P, 0.90)
+        self.assertGreaterEqual(R, 0.91)
+        self.assertGreaterEqual(F, 0.91)
 
     def test_svm(self):
         try:
@@ -990,9 +990,9 @@ class TestClassifier(unittest.TestCase):
         # Assert the accuracy of the classifier.
         A, P, R, F, o = vector.SVM.test(self.model, folds=10, type=vector.SVC, kernel=vector.LINEAR)
         #print(A, P, R, F, o)
-        self.assertTrue(P >= 0.93)
-        self.assertTrue(R >= 0.93)
-        self.assertTrue(F >= 0.93)
+        self.assertGreaterEqual(P, 0.93)
+        self.assertGreaterEqual(R, 0.93)
+        self.assertGreaterEqual(F, 0.93)
 
     def test_liblinear(self):
         # If LIBLINEAR can be loaded,

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -490,7 +490,7 @@ class TestSearchEngine(unittest.TestCase):
             return
         t = time.time()
         e = Engine(license=license, throttle=0.25, language="en")
-        v = e.search(query, type, start=1, count=1, cached=False)
+        v = e.search(query, type, start=1, count=1, cached=False, timeout=30)
         t = time.time() - t
         self.assertTrue(t >= 0.25)
         self.assertEqual(e.license, license)


### PR DESCRIPTION
Pin the subversion of Python and fix the ci config to actually use it, as said in #262 . The subversion 3.6.5 was chosen as it is the latest known to pass in every test, which should be updated in the near future.
