### PR TITLE
Fix master CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ language: python
 dist: precise
 
 python:
+  - "2.7"
   - "3.6"
+  - "3.7"
 
 before_install:
+  # Define TZ as some tests rely on timezone
   - export TZ=Europe/Brussels
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda update --yes conda
-  - conda install --yes numpy scipy
   - pip install --quiet pytest pytest-cov pytest-xdist chardet
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: precise
+dist: xenial
 
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ before_install:
 install:
   - python setup.py install --quiet
   - pip freeze
-  # Install and compile libsvm and liblinear
-  - sudo apt-get install -y build-essential
-  - git clone https://github.com/cjlin1/libsvm
-  - cd libsvm; make lib; sudo cp libsvm.so.2 /lib; sudo ln -s /lib/libsvm.so.2 /lib/libsvm.so; cd ..
-  - git clone https://github.com/cjlin1/liblinear
-  - cd liblinear; make lib; sudo cp liblinear.so.3 /lib; sudo ln -s /lib/liblinear.so.3 /lib/liblinear.so; cd ..
+  # No need to recompile libsvm and liblinear, can rely on the precompiled commited versions, so removes an eventual installed version
+  - path_to_libsvm=$(ldconfig -p | grep -m1 "libsvm.so.2" | cut -d ' ' -f4)
+  - if [[ -e $path_to_libsvm ]]; then sudo rm -f $path_to_libsvm; fi
+  - path_to_liblinear=$(ldconfig -p | grep -m1 "liblinear.so.3" | cut -d ' ' -f4)
+  - if [[ -e $path_to_liblinear ]]; then sudo rm -f $path_to_liblinear; fi
+  - sudo ldconfig
 
 script:
   - pytest --cov=pattern

--- a/pattern/text/__init__.py
+++ b/pattern/text/__init__.py
@@ -606,7 +606,7 @@ def _read(path, encoding="utf-8", comment=";;;"):
             if not line or (comment and line.startswith(comment)):
                 continue
             yield line
-    raise StopIteration
+    return
 
 
 class Lexicon(lazydict):

--- a/pattern/vector/svm/liblinear.py
+++ b/pattern/vector/svm/liblinear.py
@@ -39,7 +39,7 @@ except:
 	elif find_library('liblinear'):
 		liblinear = CDLL(find_library('liblinear'))
 	else:
-		libsvm = CDLL(path.join(path.dirname(__file__), 'ubuntu/liblinear-2.20/liblinear.so.3'))
+		liblinear = CDLL(path.join(path.dirname(__file__), 'ubuntu/liblinear-2.20/liblinear.so.3'))
 
 L2R_LR = 0
 L2R_L2LOSS_SVC_DUAL = 1

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -768,8 +768,8 @@ class _TestQuery(object):
             "select persons.* from `persons` where persons.age<30 or persons.name='john';",
             [(1, "john", 30, 2),
              (2, "jack", 20, 2)]),
-          (dict(fields=["name", "gender.name"], relations=[db.relation("gender", "id", "gender")]),
-            "select persons.name, gender.name from `persons` left join `gender` on persons.gender=gender.id;",
+          (dict(fields=["name", "gender.name"], relations=[db.relation("gender", "id", "gender")], sort=["persons.id"]),
+            "select persons.name, gender.name from `persons` left join `gender` on persons.gender=gender.id order by persons.id asc;",
             [("john", "male"),
              ("jack", "male"),
              ("jane", "female")]),
@@ -801,11 +801,11 @@ class _TestQuery(object):
             self.assertEqual(v.SQL(), sql)
             self.assertEqual(v.rows(), rows)
         # Assert Database.link() permanent relations.
-        v = self.db.persons.search(fields=["name", "gender.name"])
+        v = self.db.persons.search(fields=["name", "gender.name"], sort=["persons.id"])
         v.aliases["gender.name"] = "gender"
         self.db.link("persons", "gender", "gender", "id", join=db.LEFT)
         self.assertEqual(v.SQL(),
-            "select persons.name, gender.name as gender from `persons` left join `gender` on persons.gender=gender.id;")
+            "select persons.name, gender.name as gender from `persons` left join `gender` on persons.gender=gender.id order by persons.id asc;")
         self.assertEqual(v.rows(),
             [('john', 'male'),
              ('jack', 'male'),
@@ -815,7 +815,7 @@ class _TestQuery(object):
 
     def test_xml(self):
         # Assert Query.xml dump.
-        v = self.db.persons.search(fields=["name", "gender.name"])
+        v = self.db.persons.search(fields=["name", "gender.name"], sort=["persons.id"])
         v.aliases["gender.name"] = "gender"
         self.db.link("persons", "gender", "gender", "id", join=db.LEFT)
         self.assertEqual(v.xml,

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -63,7 +63,7 @@ def create_db_sqlite():
         password = PASSWORD)
 
     # Drop all tables first
-    for table in list(DB_MYSQL.tables):
+    for table in list(DB_SQLITE.tables):
         DB_SQLITE.drop(table)
 
     return DB_SQLITE

--- a/test/test_text.py
+++ b/test/test_text.py
@@ -9,6 +9,7 @@ from builtins import map, zip, filter
 from builtins import object, range
 
 import os
+from random import seed
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import unittest
@@ -92,6 +93,7 @@ class TestModel(unittest.TestCase):
     def test_model(self):
         # Assert SLP language model.
         v = text.Model()
+        seed(0)  # Reset RNG seed set by current time inside the constructor above
         for i in range(2):
             v.train("black", "JJ", previous=("the", "DT"), next=("cat", "NN"))
             v.train("on", "IN", previous=("sat", "VBD"), next=("the", "DT"))

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -534,7 +534,18 @@ class TestSearchEngine(unittest.TestCase):
         self._test_search_engine("Bing", *self.api["Bing"])
 
     def test_search_twitter(self):
-        self._test_search_engine("Twitter", *self.api["Twitter"])
+        n_tries = 5
+        for i in range(n_tries):
+            try:
+                self._test_search_engine("Twitter", *self.api["Twitter"])
+                break
+            except AssertionError:
+                if i < n_tries - 1:
+                    # Sleep for a moment to try again
+                    time.sleep(30)
+                    pass
+                else:
+                    raise
 
     @unittest.skip('Mediawiki/Wikipedia API or appearance changed')
     def test_search_wikipedia(self):


### PR DESCRIPTION
The main idea of this PR is to fix the CI. It was testing for Python 3.7 from the miniconda installation which weren't even necessary.
The libsvm and liblinear have both updated and were causing the CI to skip their test, as the tests are configured to pass on an ImportError, now the CI relies on the bundled Ubuntu's versions. I decided to update the Ubuntu image as recommended by Travis.
Some errors were found in the process, in the SQLite tests, trying to drop MySQL tables, and liblinear being loaded in the libsvm variable.
Some tests were relying on RNG results without seed and default SELECT order, those got fixed as well.
The twitter API is somewhat unstable for tests so I added a retry loop in it.