### PR TITLE
fix(setup): require pdfminer for python 3 and pdfminer.six for python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ setup(
         "beautifulsoup4",
         "lxml",
         "feedparser",
-        "pdfminer" if sys.version < "3" else "pdfminer.six",
+        "pdfminer.six" if sys.version < "3" else "pdfminer",
         "numpy",
         "scipy",
         "nltk",


### PR DESCRIPTION
Taken from https://github.com/euske/pdfminer:

Starting from version 20191010, PDFMiner supports Python 3 only. For Python 2 support, check out pdfminer.six.