### PR TITLE
fix: `tenses` on English base form wrongly returns 3rd singular pres …

### DIFF
--- a/pattern/text/__init__.py
+++ b/pattern/text/__init__.py
@@ -2252,11 +2252,10 @@ class Verbs(lazydict):
                     if i == index:
                         a.add(id)
                 for id1, id2 in self._default.items():
-                    if id2 in a:
-                        a.add(id1)
-                for id1, id2 in self._default.items():
-                    if id2 in a:
-                        a.add(id1)
+                    # don't return tenses with more specific form
+                    if id2 in a and not v[id1]:
+                        a.add(id1) 
+                    
 
         a = list(TENSES[id][:-2] for id in a)
 


### PR DESCRIPTION
Via a mapping from specific tense ids to defaults, `tenses` on English base forms wrongly yields the 3rd person singular indicative present as a candidate tense.

Example of previous faulty output: Attempting to get all forms of "demonstrate" that are parallel to the form "show"

     >>> import pattern.en as enp
     >>> candidate_tenses = enp.tenses('show')
     >>> print(set([enp.conjugate('demonstrate', *t) for t in candidate_tenses]))
    {'demonstrate', 'demonstrates'}

Fixed by ignoring the default mapping when the tense_id has a specied form of its own.
  
  