### PR TITLE
StopIteration & RuntimeError fix for Python >= 3.7

### DIFF
--- a/pattern/text/__init__.py
+++ b/pattern/text/__init__.py
@@ -606,7 +606,6 @@ def _read(path, encoding="utf-8", comment=";;;"):
             if not line or (comment and line.startswith(comment)):
                 continue
             yield line
-    raise StopIteration
 
 
 class Lexicon(lazydict):


### PR DESCRIPTION
Since Python 3.7, all StopIteration exceptions raised inside a generator are transformed into RuntimeError (see [PEP-0479](https://www.python.org/dev/peps/pep-0479/#id38) and [this answer from StackOverflow](https://stackoverflow.com/a/51701040)). This new behavior made _pattern_ unusable for all Python3.7+ users and all packages depending on it (gensim for instance: https://github.com/RaRe-Technologies/gensim/issues/2438).

This PR fixes the _read generator by removing the StopIteration exception raised in it. It solves the following issues :
* https://github.com/clips/pattern/issues/243
* https://github.com/clips/pattern/issues/282
* https://github.com/clips/pattern/issues/283
* https://github.com/clips/pattern/issues/288
* https://github.com/RaRe-Technologies/gensim/issues/2438
