### PR TITLE
Fix MediaWiki.index()

### DIFF
--- a/pattern/web/__init__.py
+++ b/pattern/web/__init__.py
@@ -2382,8 +2382,7 @@ class MediaWiki(SearchEngine):
             for x in data.get("query", {}).get("allpages", {}):
                 if x.get(id):
                     yield x[id]
-            start = data.get("query-continue", {}).get("allpages", {})
-            start = start.get("apcontinue", start.get("apfrom", -1))
+            start = data.get("continue", {}).get("apcontinue", -1)
         raise StopIteration
 
     # Backwards compatibility.


### PR DESCRIPTION
The old code fetched non existing fields, resulting in an aborted iteration after the first "batch" of articles. 
This was probably due to a change in the underlying MediaWiki API. 

Reference: https://meta.wikimedia.org/w/api.php?action=help&modules=query%2Ballpages