### PR TITLE
Fix/english particle verbs to dev

### DIFF
--- a/pattern/text/de/inflect.py
+++ b/pattern/text/de/inflect.py
@@ -493,7 +493,7 @@ faux_prefix_verbs = (
     'zerren', 'zuenden',  # zünden
     'zuzeln', 'gellen', 'zuechten',  # züchten
     'ankern', 'angeln', 'herzigen', # 'be-herzigen after decomposition
-    'dauern', 'darben', 'danken', # for whatever reason 'da' appears in prefix_separable
+    'dauern', 'darben', 'danken', 'daten' # for whatever reason 'da' appears in prefix_separable
 )  # probably more
 
 faux_latinate = (

--- a/pattern/text/en/inflect.py
+++ b/pattern/text/en/inflect.py
@@ -731,12 +731,15 @@ class Verbs(_Verbs):
                 return v + "e"      # decre => decree
             if v.endswith(("th", "ang", "un", "cr", "vr", "rs", "ps", "tr")):
                 return v + "e"
-        return verb
+        return v
 
     def conjugate(self, verb, *args, **kwargs):
         verb, sattelites = self.decompose_particle_verb(verb)
         conjugated_verb = _Verbs.conjugate(self, verb, *args, **kwargs)
-        return ' '.join([conjugated_verb, sattelites])
+        if sattelites:
+            return ' '.join([conjugated_verb, sattelites])
+        else:
+            return conjugated_verb
 
     def find_lexeme(self, verb):
         """ For a regular verb (base form), returns the forms using a rule-based approach.

--- a/pattern/text/en/inflect.py
+++ b/pattern/text/en/inflect.py
@@ -655,10 +655,37 @@ class Verbs(_Verbs):
                 29: 32, 30: 32, 31: 32, 32: 33  # past plural negated
             })
 
+    def decompose_particle_verb(self, verb):
+        try:
+            if len(verb.split()) > 1:
+                verb, sattelites = verb.split(' ', 1)
+            else:
+                sattelites = ''
+        except Exception as e:
+            sattelites = ''
+
+        return verb, sattelites
+
+    def tenses(self, verb, parse=True):
+        if parse:
+            verb, _ = self.decompose_particle_verb(verb)
+        return _Verbs.tenses(self, verb, parse=parse)
+
+    def lemma(self, verb, parse=True):
+        if parse:
+            verb, sattelites = self.decompose_particle_verb(verb)
+            lemmatized = _Verbs.lemma(self, verb, parse=parse)
+            if sattelites:
+                return ' '.join([lemmatized, sattelites])
+            return lemmatized
+        else:
+            return _Verbs.lemma(self, verb, parse=parse)
+
     def find_lemma(self, verb):
         """ Returns the base form of the given inflected verb, using a rule-based approach.
             This is problematic if a verb ending in -e is given in the past tense or gerund.
         """
+
         v = verb.lower()
         b = False
         if v in ("'m", "'re", "'s", "n't"):
@@ -704,7 +731,12 @@ class Verbs(_Verbs):
                 return v + "e"      # decre => decree
             if v.endswith(("th", "ang", "un", "cr", "vr", "rs", "ps", "tr")):
                 return v + "e"
-        return v
+        return verb
+
+    def conjugate(self, verb, *args, **kwargs):
+        verb, sattelites = self.decompose_particle_verb(verb)
+        conjugated_verb = _Verbs.conjugate(self, verb, *args, **kwargs)
+        return ' '.join([conjugated_verb, sattelites])
 
     def find_lexeme(self, verb):
         """ For a regular verb (base form), returns the forms using a rule-based approach.


### PR DESCRIPTION
Correct results for `pattern.en.lemma`/`pattern.en.conjugate`/`pattern.en.tenses` with particle verbs by splitting the input into verb stem and sattelites (first word and everything else) before doing the base class `_Verb` processing.

example:
```
>>> import pattern.en as enp
>>> print(enp.conjugate("dispose of", list(enp.tenses("discarded"))[0])) # old result was: 'dispose offed'
'disposed of'
```

