### PR TITLE
Work around requirementslib AttributeError

### DIFF
--- a/pattern/__init__.py
+++ b/pattern/__init__.py
@@ -44,7 +44,7 @@ from __future__ import unicode_literals
 
 __author__    = "Tom De Smedt"
 __credits__   = "Tom De Smedt, Walter Daelemans"
-__version__   = "3.6"
+__version__   = "3.7"
 __copyright__ = "Copyright (c) 2010 University of Antwerp (BE)"
 __license__   = "BSD"
 

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
         "Topic :: Text Processing :: Linguistic",
         "Topic :: Text Processing :: Markup :: HTML"
     ],
-    install_requires = [
+    install_requires = list([
         "future",
         "backports.csv",
         "mysqlclient",
@@ -148,6 +148,6 @@ setup(
         "python-docx",
         "cherrypy",
         "requests"
-    ],
+    ]),
     zip_safe = False
 )


### PR DESCRIPTION
(This also fixes bumping `setup.py` version but not the module's `__version__`, intended for squashing.)

See https://github.com/pypa/pipenv/issues/5167#issuecomment-1349316531

This could lead to failures like

    $ pipenv install
    Pipfile.lock (6c5d3c) out of date, updating to (dd7943)...
    Locking [packages] dependencies...
    ⠸ Resolving dependencies...
    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/pipenv/resolver.py", line 845, in <module>
        main()
      File "/usr/lib/python3/dist-packages/pipenv/resolver.py", line 831, in main
        _main(
      File "/usr/lib/python3/dist-packages/pipenv/resolver.py", line 811, in _main
        resolve_packages(
      File "/usr/lib/python3/dist-packages/pipenv/resolver.py", line 759, in resolve_packages
        results, resolver = resolve(
                            ^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/resolver.py", line 738, in resolve
        return resolve_deps(
               ^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/utils/resolver.py", line 1100, in resolve_deps
        results, hashes, markers_lookup, resolver, skipped = actually_resolve_deps(
                                                             ^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/utils/resolver.py", line 888, in actually_resolve_deps
        resolver = Resolver.create(
                   ^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/utils/resolver.py", line 458, in create
        constraints, skipped, index_lookup, markers_lookup = resolver.get_metadata(
                                                             ^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/utils/resolver.py", line 246, in get_metadata
        constraint_update, lockfile_update = self.get_deps_from_req(
                                             ^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/utils/resolver.py", line 325, in get_deps_from_req
        req_list, lockfile = get_vcs_deps(reqs=[req])
                             ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/utils/dependencies.py", line 125, in get_vcs_deps
        with temp_path(), locked_repository(requirement) as repo:
      File "/usr/lib/python3.11/contextlib.py", line 137, in __enter__
        return next(self.gen)
               ^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/utils/dependencies.py", line 375, in locked_repository
        with requirement.req.locked_vcs_repo(src_dir=src_dir) as repo:
      File "/usr/lib/python3.11/contextlib.py", line 137, in __enter__
        return next(self.gen)
               ^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/requirements.py", line 2203, in locked_vcs_repo
        self._parsed_line.vcsrepo = vcsrepo
        ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/requirements.py", line 903, in vcsrepo
        setupinfo = SetupInfo.create(
                    ^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 1564, in create
        created.get_initial_info()
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 1393, in get_initial_info
        parsed.update(self.parse_setup_py())
                      ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 1118, in parse_setup_py
        parsed = ast_parse_setup_py(self.setup_py.as_posix())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 839, in ast_parse_setup_py
        return SetupReader.read_setup_py(Path(path), raising)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 180, in read_setup_py
        "install_requires": caller(cls._find_install_requires, setup_call, body),
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 172, in caller
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 335, in _find_install_requires
        return [el.s for el in value.elts]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 335, in <listcomp>
        return [el.s for el in value.elts]
                ^^^^
    AttributeError: 'IfExp' object has no attribute 's'